### PR TITLE
Added the clean-measurements command and added it to the scheduler

### DIFF
--- a/app/Console/Commands/CleanMeasurements.php
+++ b/app/Console/Commands/CleanMeasurements.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Delta\DeltaService\Measurements\MeasurementRepositoryInterface;
+use DateTime;
+use Illuminate\Console\Command;
+
+class CleanMeasurements extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clean-measurements';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove measurements that are more than half a year old';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param $measurementRepository
+     *
+     * @return void
+     */
+    public function handle(MeasurementRepositoryInterface $measurementRepository)
+    {
+        $date = new DateTime();
+        $date->modify('-6 month');
+        $measurementRepository->removeOlderThan($date);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\CleanMeasurements;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        CleanMeasurements::class
     ];
 
     /**
@@ -24,8 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        $schedule->command('clean-measurements')->daily();
     }
 
     /**


### PR DESCRIPTION
Added new command clean-measurements that removes measurements older than 6 months. This command is scheduled using the Laravel scheduler to run daily.
